### PR TITLE
fix gob archive documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,13 +69,13 @@ Tools for Star Wars: Dark Forces and Outlaws assets.
 
 **Make a GOB**
 
-`python gobtool.py archive "CUSTOM.GOB" "CUSTOM"`
+`python gobtool.py archive "CUSTOM" "CUSTOM.GOB"`
 
 *Archives all of the files in folder "CUSTOM" (top-level only) in the current directory, to a GOB named "CUSTOM.GOB" in the current directory.*
 
-`python gobtool.py archive -r "CUSTOM.GOB" "CUSTOM"`
+`python gobtool.py archive -r "CUSTOM" "CUSTOM.GOB"`
 
-`python gobtool.py archive --recursive "CUSTOM.GOB" "CUSTOM"`
+`python gobtool.py archive --recursive "CUSTOM" "CUSTOM.GOB"`
 
 *Archives all of the files in folder "CUSTOM" (including subdirectories) in the current directory, to a GOB named "CUSTOM.GOB" in the current directory.*
 


### PR DESCRIPTION
The gob archive command documentation seems backwards.
![image](https://github.com/njankowski/dftools/assets/1442484/aa86f2d5-1fed-4d05-a797-f4f051d8537e)
